### PR TITLE
dnsmgr.c: dnsmgr_refresh() should not flag change if IP address order changes

### DIFF
--- a/include/asterisk/acl.h
+++ b/include/asterisk/acl.h
@@ -288,6 +288,33 @@ int ast_get_ip(struct ast_sockaddr *addr, const char *hostname);
 int ast_get_ip_or_srv(struct ast_sockaddr *addr, const char *hostname, const char *service);
 
 /*!
+ * \brief Get the IP address given a hostname and optional service with a preferred result
+ *
+ * \details
+ * If the service parameter is non-NULL, then an SRV lookup will be made by
+ * prepending the service to the hostname parameter, separated by a '.'
+ * For example, if hostname is "example.com" and service is "_sip._udp" then
+ * an SRV lookup will be done for "_sip._udp.example.com". If service is NULL,
+ * then this function acts exactly like a call to ast_get_ip.
+ *
+ * \param addr The IP address found.  The address family is used as an input
+ * parameter to filter the returned addresses.  If it is 0, both IPv4 and
+ * IPv6 addresses can be returned.
+ *
+ * \param hostname The hostname to look up
+ * \param service A specific service provided by the host. A NULL service results
+ * in an A-record lookup instead of an SRV lookup
+ * \param preference The preferred IP address to return. If multiple results are
+ * available and this IP address is in the list then it will be returned. If NULL,
+ * or if the none of the returned IP addresses match, then the first IP address
+ * will be returned.
+ * \retval 0 Success
+ * \retval -1 Failure
+ */
+int ast_get_ip_or_srv_with_preference(struct ast_sockaddr *addr, const char *hostname,
+									  const char *service, struct ast_sockaddr *preference);
+
+/*!
  * \brief Get our local IP address when contacting a remote host
  *
  * \details

--- a/main/dnsmgr.c
+++ b/main/dnsmgr.c
@@ -211,7 +211,7 @@ static int dnsmgr_refresh(struct ast_dnsmgr_entry *entry, int verbose)
 	ast_debug(6, "refreshing '%s'\n", entry->name);
 
 	tmp.ss.ss_family = entry->family;
-	if (!ast_get_ip_or_srv(&tmp, entry->name, entry->service)) {
+	if (!ast_get_ip_or_srv_with_preference(&tmp, entry->name, entry->service, entry->result)) {
 		if (!ast_sockaddr_port(&tmp)) {
 			ast_sockaddr_set_port(&tmp, ast_sockaddr_port(entry->result));
 		}


### PR DESCRIPTION
The dnsmgr_refresh() function checks to see if the IP address associated with a name/service has changed.  The gotcha is that the ast_get_ip_or_srv() function only returns the first IP address returned by the DNS query. If there are multiple IPs associated with the name and the returned order is not consistent (e.g. with DNS round-robin) then the other IP addresses are not included in the comparison and the entry is flagged as changed even though the IP is still valid.

Updated the code to check all IP addresses and flag a change only if the original IP is no longer valid.